### PR TITLE
Add property to enable controls in fullscreen

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -173,6 +173,7 @@ class ChewieController extends ChangeNotifier {
     this.overlay,
     this.showControlsOnInitialize = true,
     this.showControls = true,
+    this.showControlsInFullScreen = true,
     this.customControls,
     this.errorBuilder,
     this.allowedScreenSleep = true,
@@ -211,6 +212,9 @@ class ChewieController extends ChangeNotifier {
 
   /// Whether or not to show the controls at all
   final bool showControls;
+
+  /// Whether or not to show controls in fullscreen mode
+  final bool showControlsInFullScreen;
 
   /// Defines customised controls. Check [MaterialControls] or
   /// [CupertinoControls] for reference.

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -32,7 +32,11 @@ class PlayerWithControls extends StatelessWidget {
               backgroundColor: Color.fromRGBO(41, 41, 41, 0.7),
               iconColor: Color.fromARGB(255, 200, 200, 200),
             );
-      return chewieController.showControls ? chewieController.customControls ?? controls : Container();
+      return chewieController.showControls
+          ? chewieController.customControls ?? controls
+          : (chewieController.isFullScreen && chewieController.showControlsInFullScreen)
+              ? chewieController.customControls ?? controls
+              : Container();
     }
 
     Stack _buildPlayerWithControls(ChewieController chewieController, BuildContext context) {


### PR DESCRIPTION
Right now, 'showControls' only allows for enabling controls in both fullscreen and non-fullscreen mode. With the added 'showControlsInFullscreen' property, one can, e. g., show controls in fullscreen while hiding them in non-fullscreen mode.